### PR TITLE
Remove org.freedesktop.Notifications bus access

### DIFF
--- a/com.mongodb.Compass.json
+++ b/com.mongodb.Compass.json
@@ -17,7 +17,6 @@
         "--filesystem=home",
         "--talk-name=org.freedesktop.secrets",
         "--talk-name=org.freedesktop.FileManager1",
-        "--talk-name=org.freedesktop.Notifications",
         "--share=network"
     ],
     "modules": [


### PR DESCRIPTION
The electron baseapp has libnotify 0.8 which uses the portal for notifications, so this is no longer required

See https://gitlab.gnome.org/GNOME/libnotify/-/blob/69aff6e5fa2842e00b409c348bd73188548828b3/NEWS#L25