### PR TITLE
fix: can't save passwords to kwallet6

### DIFF
--- a/com.mongodb.Compass.json
+++ b/com.mongodb.Compass.json
@@ -14,8 +14,11 @@
         "--share=ipc",
         "--socket=x11",
         "--socket=pulseaudio",
+        "--device=dri",
         "--filesystem=home",
         "--talk-name=org.freedesktop.secrets",
+        "--talk-name=org.kde.kwalletd5",
+        "--talk-name=org.kde.kwalletd6",
         "--talk-name=org.freedesktop.FileManager1",
         "--share=network"
     ],


### PR DESCRIPTION
Fix https://github.com/flathub/com.mongodb.Compass/issues/72, and enable GPU rendering.