### PR TITLE
change-base-image-last-version-is-built-for-node24

### DIFF
--- a/com.mongodb.Compass.appdata.xml
+++ b/com.mongodb.Compass.appdata.xml
@@ -14,11 +14,11 @@
     <screenshots>
         <screenshot type="default">
             <caption>Query and explore MongoDB collections from the Compass data view.</caption>
-            <image>https://www.mongodb.com/docs/compass/current/images/tabs/query-your-data.png</image>
+            <image>https://www.mongodb.com/docs/compass/images/tabs/query-your-data.png</image>
         </screenshot>
         <screenshot>
             <caption>Run MongoDB shell commands directly inside Compass.</caption>
-            <image>https://www.mongodb.com/docs/compass/current/images/tabs/run-commands-in-the-shell.png</image>
+            <image>https://www.mongodb.com/docs/compass/images/tabs/run-commands-in-the-shell.png</image>
         </screenshot>
     </screenshots>
     <url type="homepage">https://www.mongodb.com/</url>

--- a/com.mongodb.Compass.appdata.xml
+++ b/com.mongodb.Compass.appdata.xml
@@ -25,6 +25,9 @@
     <developer_name>MongoDB Inc.</developer_name>
     <launchable type="desktop-id">com.mongodb.Compass.desktop</launchable>
     <releases>
+        <release version="1.49.9" date="2026-06-12">
+            <description></description>
+        </release>
         <release version="1.49.8" date="2026-05-26">
             <description></description>
         </release>

--- a/com.mongodb.Compass.json
+++ b/com.mongodb.Compass.json
@@ -6,7 +6,7 @@
     "runtime-version": "25.08",
     "sdk": "org.freedesktop.Sdk",
     "sdk-extensions": [
-        "org.freedesktop.Sdk.Extension.node22"
+        "org.freedesktop.Sdk.Extension.node24"
     ],
     "command": "run.sh",
     "separate-locales": false,

--- a/com.mongodb.Compass.json
+++ b/com.mongodb.Compass.json
@@ -58,8 +58,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/mongodb-js/compass/releases/download/v1.49.8/mongodb-compass-1.49.8-linux-x64.tar.gz",
-                    "sha256": "6d381cc12797f86988b843f45f8a1c7791d7ef5d7b32aabf6aa627ecbfb5208f",
+                    "url": "https://github.com/mongodb-js/compass/releases/download/v1.49.9/mongodb-compass-1.49.9-linux-x64.tar.gz",
+                    "sha256": "e0e2b4acb7e7685b7cec1aa4d9dc2df6a3a7b8ae6f0d78fe7d1fa46d48590a50",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/mongodb-js/compass/releases/latest",

--- a/com.mongodb.Compass.json
+++ b/com.mongodb.Compass.json
@@ -12,8 +12,9 @@
     "separate-locales": false,
     "finish-args": [
         "--share=ipc",
-        "--socket=x11",
         "--socket=pulseaudio",
+        "--socket=wayland",
+        "--socket=fallback-x11",
         "--device=dri",
         "--filesystem=home",
         "--talk-name=org.freedesktop.secrets",


### PR DESCRIPTION
https://github.com/mongodb-js/compass/releases/tag/v1.49.9
feat: upgrade electron to 41 and nodejs to 24 [COMPASS-9852](https://jira.mongodb.org/browse/COMPASS-9852)
in a bug fix release... WTF